### PR TITLE
api.use nprogress

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,3 +1,4 @@
 Package.on_use(function (api) {
+    api.use('nprogress');
     api.add_files('auto-nprogress.js', 'client'); // Or 'client', or ['server', 'client']
 });


### PR DESCRIPTION
fixes: Uncaught ReferenceError: NProgress is not defined

Just added the package to a project on Meteor 0.7.0.1 and was seeing this error.
We need to use the nprogress package so that we have the NProgress object

Edit: I could explain a bit clearer, the error is triggered from auto-nprogress.js (specifically line 6) because the package cannot see NProgress unless we define api.use within the package.js :)
